### PR TITLE
WFLY-4705 Enable interface declaration in subsystem template

### DIFF
--- a/provisioning/src/main/java/org/wildfly/build/configassembly/ConfigurationAssembler.java
+++ b/provisioning/src/main/java/org/wildfly/build/configassembly/ConfigurationAssembler.java
@@ -85,6 +85,7 @@ public class ConfigurationAssembler {
         final Set<String> extensions = new TreeSet<String>();
         final Map<String, Map<String, ElementNode>> socketBindingsByGroup = new HashMap<String, Map<String, ElementNode>>();
         final Map<String, Map<String, ElementNode>> outboundSocketBindingsByGroup = new HashMap<String, Map<String, ElementNode>>();
+        final Map<String, ElementNode> interfaces = new TreeMap<String, ElementNode>();
         for (Map.Entry<String, ProcessingInstructionNode> subsystemEntry : templateParser.getSubsystemPlaceholders().entrySet()) {
             final String profileName = subsystemEntry.getKey();
             final String groupName = subsystemEntry.getValue().getDataValue("socket-binding-group", "");
@@ -120,6 +121,9 @@ public class ConfigurationAssembler {
                         throw new IllegalStateException("Outbound SocketBinding '" + entry + "' already exists");
                     }
                     outboundSocketBindings.put(entry.getKey(), entry.getValue());
+                }
+                for (Map.Entry<String, ElementNode> entry : subsystemParser.getInterfaces().entrySet()) {
+                        interfaces.put(entry.getKey(), entry.getValue());
                 }
             }
         }
@@ -165,6 +169,12 @@ public class ConfigurationAssembler {
                         entry.getValue().addDelegate(binding);
                     }
                 }
+            }
+        }
+        if (interfaces.size() > 0) {
+            final ProcessingInstructionNode interfacesNode = templateParser.getInterfacesPlaceHolders();
+            for (ElementNode interfaceElement : interfaces.values()) {
+                interfacesNode.addDelegate(interfaceElement);
             }
         }
     }

--- a/provisioning/src/main/java/org/wildfly/build/configassembly/SubsystemParser.java
+++ b/provisioning/src/main/java/org/wildfly/build/configassembly/SubsystemParser.java
@@ -56,6 +56,7 @@ class SubsystemParser extends NodeParser {
     private final Map<String, Set<ProcessingInstructionNode>> supplementPlaceholders = new HashMap<String, Set<ProcessingInstructionNode>>();
     private final Map<String, Supplement> supplementReplacements = new HashMap<String, Supplement>();
     private final Map<String, List<AttributeValue>> attributesForReplacement = new HashMap<String, List<AttributeValue>>();
+    private final Map<String, ElementNode> interfaces = new HashMap<String, ElementNode>();
 
     SubsystemParser(String socketBindingNamespace, String supplementName, InputStreamSource inputStreamSource){
         this.socketBindingNamespace = socketBindingNamespace;
@@ -73,6 +74,10 @@ class SubsystemParser extends NodeParser {
 
     Map<String, ElementNode> getSocketBindings(){
         return socketBindings;
+    }
+
+    Map<String, ElementNode> getInterfaces(){
+        return interfaces;
     }
 
     Map<String, ElementNode> getOutboundSocketBindings(){
@@ -105,6 +110,9 @@ class SubsystemParser extends NodeParser {
                     } else if (reader.getLocalName().equals("outbound-socket-binding")) {
                         ElementNode socketBinding = new NodeParser(socketBindingNamespace).parseNode(reader, "outbound-socket-binding");
                         outboundSocketBindings.put(socketBinding.getAttributeValue("name"), socketBinding);
+                    } else if (reader.getLocalName().equals("interface")) {
+                        ElementNode iface = new NodeParser(socketBindingNamespace).parseNode(reader, "interface");
+                        interfaces.put(iface.getAttributeValue("name"), iface);
                     }
                 }
             }


### PR DESCRIPTION
Currently there is no possibility to define interface in subsystem definition. As a result of that interface "unsecure" which is used only by IIOP subsystem has to be defined in all configuration files. As a result of this change there will be possibilty to move "unsecure" interface definition to iiop-subsystem so that only those configurations that contain iiop subsystem would have this interface defined.