### PR TITLE
WFLY-5383 add support for extracting schemas only for configured mave…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>16</version>
+        <version>19</version>
     </parent>
 
     <groupId>org.wildfly.build</groupId>
@@ -79,7 +79,7 @@
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
-        <version.org.wildfly.checkstyle-config>1.0.0.Final</version.org.wildfly.checkstyle-config>
+        <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
     </properties>
 
@@ -125,7 +125,7 @@
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${version.checkstyle.plugin}</version>
                     <configuration>
-                        <configLocation>jboss-as-checkstyle/checkstyle.xml</configLocation>
+                        <configLocation>wildfly-checkstyle/checkstyle.xml</configLocation>
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/Attribute.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/Attribute.java
@@ -30,6 +30,7 @@ enum Attribute {
 
     COPY_MODULE_ARTIFACTS("copy-module-artifacts"),
     EXTRACT_SCHEMAS("extract-schemas"),
+    EXTRACT_SCHEMAS_GROUPS("extract-schemas-groups"),
     PATTERN("pattern"),
     INCLUDE("include"),
     TRANSITIVE("transitive"),
@@ -57,6 +58,7 @@ enum Attribute {
         attributesMap.put(new QName(VALUE.getLocalName()), VALUE);
         attributesMap.put(new QName(COPY_MODULE_ARTIFACTS.getLocalName()), COPY_MODULE_ARTIFACTS);
         attributesMap.put(new QName(EXTRACT_SCHEMAS.getLocalName()), EXTRACT_SCHEMAS);
+        attributesMap.put(new QName(EXTRACT_SCHEMAS_GROUPS.getLocalName()), EXTRACT_SCHEMAS_GROUPS);
         attributesMap.put(new QName(GROUP_ID.getLocalName()), GROUP_ID);
         attributesMap.put(new QName(ARTIFACT_ID.getLocalName()), ARTIFACT_ID);
         attributesMap.put(new QName(CLASSIFIER.getLocalName()), CLASSIFIER);

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/Element.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/Element.java
@@ -16,16 +16,16 @@
 
 package org.wildfly.build.provisioning.model;
 
-import org.wildfly.build.common.model.CopyArtifactsModelParser10;
-import org.wildfly.build.common.model.FileFilterModelParser10;
-
-import javax.xml.namespace.QName;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.wildfly.build.common.model.CopyArtifactsModelParser10;
+import org.wildfly.build.common.model.FileFilterModelParser10;
+
 /**
-* @author Stuart Douglas
-*/
+ * @author Stuart Douglas
+ * @author Tomaz Cerar
+ */
 enum Element {
 
     // default unknown element
@@ -46,39 +46,32 @@ enum Element {
     VERSION_OVERRIDES("version-overrides"),
     VERSION_OVERRIDE("version-override"),
     COPY_ARTIFACTS(CopyArtifactsModelParser10.ELEMENT_LOCAL_NAME),
-    FILTER(FileFilterModelParser10.ELEMENT_LOCAL_NAME),
-    ;
+    FILTER(FileFilterModelParser10.ELEMENT_LOCAL_NAME);
 
-    private static final Map<QName, Element> elements;
+    private static final Map<String, Element> elements;
 
     static {
-        Map<QName, Element> elementsMap = new HashMap<QName, Element>();
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, SERVER_PROVISIONING.getLocalName()), SERVER_PROVISIONING);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, FEATURE_PACKS.getLocalName()), FEATURE_PACKS);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, FEATURE_PACK.getLocalName()), FEATURE_PACK);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, ARTIFACT.getLocalName()), ARTIFACT);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, MODULES.getLocalName()), MODULES);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, FILTER.getLocalName()), FILTER);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, CONFIG.getLocalName()), CONFIG);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, STANDALONE.getLocalName()), STANDALONE);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, DOMAIN.getLocalName()), DOMAIN);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, PROPERTY.getLocalName()), PROPERTY);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, SUBSYSTEMS.getLocalName()), SUBSYSTEMS);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, SUBSYSTEM.getLocalName()), SUBSYSTEM);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, CONTENTS.getLocalName()), CONTENTS);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, VERSION_OVERRIDES.getLocalName()), VERSION_OVERRIDES);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, VERSION_OVERRIDE.getLocalName()), VERSION_OVERRIDE);
-        elementsMap.put(new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, COPY_ARTIFACTS.getLocalName()), COPY_ARTIFACTS);
+        Map<String, Element> elementsMap = new HashMap<>();
+        elementsMap.put(SERVER_PROVISIONING.getLocalName(), SERVER_PROVISIONING);
+        elementsMap.put(FEATURE_PACKS.getLocalName(), FEATURE_PACKS);
+        elementsMap.put(FEATURE_PACK.getLocalName(), FEATURE_PACK);
+        elementsMap.put(ARTIFACT.getLocalName(), ARTIFACT);
+        elementsMap.put(MODULES.getLocalName(), MODULES);
+        elementsMap.put(FILTER.getLocalName(), FILTER);
+        elementsMap.put(CONFIG.getLocalName(), CONFIG);
+        elementsMap.put(STANDALONE.getLocalName(), STANDALONE);
+        elementsMap.put(DOMAIN.getLocalName(), DOMAIN);
+        elementsMap.put(PROPERTY.getLocalName(), PROPERTY);
+        elementsMap.put(SUBSYSTEMS.getLocalName(), SUBSYSTEMS);
+        elementsMap.put(SUBSYSTEM.getLocalName(), SUBSYSTEM);
+        elementsMap.put(CONTENTS.getLocalName(), CONTENTS);
+        elementsMap.put(VERSION_OVERRIDES.getLocalName(), VERSION_OVERRIDES);
+        elementsMap.put(VERSION_OVERRIDE.getLocalName(), VERSION_OVERRIDE);
+        elementsMap.put(COPY_ARTIFACTS.getLocalName(), COPY_ARTIFACTS);
         elements = elementsMap;
     }
 
-    static Element of(QName qName) {
-        QName name;
-        if (qName.getNamespaceURI().equals("")) {
-            name = new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, qName.getLocalPart());
-        } else {
-            name = qName;
-        }
+    static Element of(String name) {
         final Element element = elements.get(name);
         return element == null ? UNKNOWN : element;
     }

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescription.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescription.java
@@ -22,6 +22,7 @@ import org.wildfly.build.common.model.FileFilter;
 import org.wildfly.build.pack.model.Artifact;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,10 +37,13 @@ public class ServerProvisioningDescription {
     private final List<FeaturePack> featurePacks = new ArrayList<>();
     private final Set<Artifact> versionOverrides = new HashSet<>();
     private final List<CopyArtifact> copyArtifacts = new ArrayList<>();
-
     private boolean copyModuleArtifacts;
-
     private boolean extractSchemas;
+    private Set<String> extractSchemasGroups;
+
+    public ServerProvisioningDescription() {
+        setExtractSchemasGroups("org.jboss.as org.wildfly");
+    }
 
     public List<FeaturePack> getFeaturePacks() {
         return featurePacks;
@@ -59,6 +63,24 @@ public class ServerProvisioningDescription {
 
     public void setExtractSchemas(boolean extractSchemas) {
         this.extractSchemas = extractSchemas;
+    }
+
+    public Set<String> getExtractSchemasGroups() {
+        return extractSchemasGroups;
+    }
+
+    public String getExtractSchemasGroupsAsString() {
+        StringBuilder buffer = new StringBuilder();
+        for (String group: extractSchemasGroups){
+            buffer.append(group).append(" ");
+        }
+        return buffer.toString().trim();
+    }
+
+    public void setExtractSchemasGroups(String groups) {
+        this.extractSchemasGroups = new HashSet<>(Arrays.asList(groups.split(" ")));
+        System.out.println("groups = " + groups);
+        System.out.println("groups = " + extractSchemasGroups);
     }
 
     public Set<Artifact> getVersionOverrides() {

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 public class ServerProvisioningDescriptionModelParser {
 
     private static final QName ROOT_1_0 = new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, Element.SERVER_PROVISIONING.getLocalName());
+    private static final QName ROOT_1_1 = new QName(ServerProvisioningDescriptionModelParser11.NAMESPACE_1_1, Element.SERVER_PROVISIONING.getLocalName());
 
     private static final XMLInputFactory INPUT_FACTORY = XMLInputFactory.newInstance();
 
@@ -39,6 +40,7 @@ public class ServerProvisioningDescriptionModelParser {
     public ServerProvisioningDescriptionModelParser(PropertyResolver properties) {
         mapper = XMLMapper.Factory.create();
         mapper.registerRootElement(ROOT_1_0, new ServerProvisioningDescriptionModelParser10(properties));
+        mapper.registerRootElement(ROOT_1_1, new ServerProvisioningDescriptionModelParser11(properties));
     }
 
     public ServerProvisioningDescription parse(final InputStream input) throws XMLStreamException {

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser10.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser10.java
@@ -50,8 +50,8 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
 
     public static final String NAMESPACE_1_0 = "urn:wildfly:server-provisioning:1.0";
 
-    private final BuildPropertyReplacer propertyReplacer;
-    private final CopyArtifactsModelParser10 copyArtifactsModelParser;
+    final BuildPropertyReplacer propertyReplacer;
+    final CopyArtifactsModelParser10 copyArtifactsModelParser;
     private final FileFilterModelParser10 fileFilterModelParser;
 
     ServerProvisioningDescriptionModelParser10(PropertyResolver resolver) {
@@ -87,7 +87,7 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
                     return;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
 
                     switch (element) {
                         case FEATURE_PACKS:
@@ -112,14 +112,14 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
         throw ParsingUtils.endOfDocument(reader.getLocation());
     }
 
-    private void parseFeaturePacks(final XMLStreamReader reader, final ServerProvisioningDescription result) throws XMLStreamException {
+    protected void parseFeaturePacks(final XMLStreamReader reader, final ServerProvisioningDescription result) throws XMLStreamException {
         while (reader.hasNext()) {
             switch (reader.nextTag()) {
                 case XMLStreamConstants.END_ELEMENT: {
                     return;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case FEATURE_PACK:
                             parseFeaturePack(reader, result);
@@ -151,7 +151,7 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
                     return;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case MODULES:
                             moduleFilters = parseModules(reader);
@@ -206,7 +206,7 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
                     return result;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case FILTER:
                             fileFilterModelParser.parseFilter(reader, result.getFilters());
@@ -244,7 +244,7 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
                     return result;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case FILTER:
                             parseModuleFilter(reader, result.getFilters());
@@ -301,7 +301,7 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
                     return;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case STANDALONE:
                             parseConfigFile(reader, result.getStandaloneConfigFiles());
@@ -354,7 +354,7 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
                     return;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case PROPERTY:
                             parseProperty(reader, properties);
@@ -411,7 +411,7 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
                     return;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case SUBSYSTEM:
                             result.add(parseSubsystem(reader));
@@ -456,14 +456,14 @@ class ServerProvisioningDescriptionModelParser10 implements XMLElementReader<Ser
         return new ServerProvisioningDescription.FeaturePack.Subsystem(name, transitive);
     }
 
-    private void parseVersionOverrides(final XMLStreamReader reader, final ServerProvisioningDescription result) throws XMLStreamException {
+    protected void parseVersionOverrides(final XMLStreamReader reader, final ServerProvisioningDescription result) throws XMLStreamException {
         while (reader.hasNext()) {
             switch (reader.nextTag()) {
                 case XMLStreamConstants.END_ELEMENT: {
                     return;
                 }
                 case XMLStreamConstants.START_ELEMENT: {
-                    final Element element = Element.of(reader.getName());
+                    final Element element = Element.of(reader.getLocalName());
                     switch (element) {
                         case VERSION_OVERRIDE:
                             result.getVersionOverrides().add(parseArtifact(reader, null, true));

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser11.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser11.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.build.provisioning.model;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.wildfly.build.util.PropertyResolver;
+import org.wildfly.build.util.xml.ParsingUtils;
+
+/**
+ * Parses the distribution build config file, i.e. the config file that is
+ * used to create a wildfly distribution.
+ *
+ * @author Tomaz Cerar
+ */
+class ServerProvisioningDescriptionModelParser11 extends ServerProvisioningDescriptionModelParser10 {
+
+    public static final String NAMESPACE_1_1 = "urn:wildfly:server-provisioning:1.1";
+
+    ServerProvisioningDescriptionModelParser11(PropertyResolver resolver) {
+        super(resolver);
+    }
+
+    /*
+    we only override this method, for now only change new EXTRACT_SCHEMAS_GROUPS attribute
+     */
+    @Override
+    public void readElement(final XMLExtendedStreamReader reader, final ServerProvisioningDescription result) throws XMLStreamException {
+        for (int i = 0; i < reader.getAttributeCount(); i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            switch (attribute) {
+                case COPY_MODULE_ARTIFACTS:
+                    result.setCopyModuleArtifacts(Boolean.parseBoolean(reader.getAttributeValue(i)));
+                    break;
+                case EXTRACT_SCHEMAS:
+                    result.setExtractSchemas(Boolean.parseBoolean(reader.getAttributeValue(i)));
+                    break;
+                case EXTRACT_SCHEMAS_GROUPS:
+                    result.setExtractSchemasGroups(reader.getAttributeValue(i));
+                    break;
+                default:
+                    System.out.println("attribute = " + attribute);
+                    throw ParsingUtils.unexpectedAttribute(reader, i);
+            }
+        }
+
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case XMLStreamConstants.END_ELEMENT: {
+                    return;
+                }
+                case XMLStreamConstants.START_ELEMENT: {
+                    final Element element = Element.of(reader.getLocalName());
+
+                    switch (element) {
+                        case FEATURE_PACKS:
+                            System.out.println("parsing feature pack");
+                            parseFeaturePacks(reader, result);
+                            break;
+                        case VERSION_OVERRIDES:
+                            parseVersionOverrides(reader, result);
+                            break;
+                        case COPY_ARTIFACTS:
+                            copyArtifactsModelParser.parseCopyArtifacts(reader, result.getCopyArtifacts());
+                            break;
+                        default:
+                            throw new XMLStreamException(String.format("Unknown element: '%s', elementName: %s, localName: %s", element, reader.getName(), reader.getLocalName()), reader.getLocation());
+                            //throw ParsingUtils.unexpectedContent(reader);
+                    }
+                    break;
+                }
+                default: {
+                    throw ParsingUtils.unexpectedContent(reader);
+                }
+            }
+        }
+        throw ParsingUtils.endOfDocument(reader.getLocation());
+    }
+
+}

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionXmlWriter.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionXmlWriter.java
@@ -71,13 +71,15 @@ public class ServerProvisioningDescriptionXmlWriter implements XMLElementWriter<
     @Override
     public void writeContent(XMLExtendedStreamWriter streamWriter, ServerProvisioningDescription description) throws XMLStreamException {
         // build node tree
-        final ElementNode rootElementNode = new ElementNode(null, Element.SERVER_PROVISIONING.getLocalName(), ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0);
+        final ElementNode rootElementNode = new ElementNode(null, Element.SERVER_PROVISIONING.getLocalName(), ServerProvisioningDescriptionModelParser11.NAMESPACE_1_1);
         if (description.isCopyModuleArtifacts()) {
             rootElementNode.addAttribute(Attribute.COPY_MODULE_ARTIFACTS.getLocalName(), new AttributeValue(Boolean.TRUE.toString()));
         }
         if (description.isExtractSchemas()) {
             rootElementNode.addAttribute(Attribute.EXTRACT_SCHEMAS.getLocalName(), new AttributeValue(Boolean.TRUE.toString()));
+            rootElementNode.addAttribute(Attribute.EXTRACT_SCHEMAS_GROUPS.getLocalName(), new AttributeValue(description.getExtractSchemasGroupsAsString()));
         }
+
         processFeaturePacks(description.getFeaturePacks(), rootElementNode);
         processVersionOverrides(description.getVersionOverrides(), rootElementNode);
         CopyArtifactsXMLWriter10.INSTANCE.write(description.getCopyArtifacts(), rootElementNode);

--- a/provisioning/src/main/java/org/wildfly/build/util/xml/ParsingUtils.java
+++ b/provisioning/src/main/java/org/wildfly/build/util/xml/ParsingUtils.java
@@ -19,11 +19,12 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 import java.util.Map;
 import java.util.Set;
-
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+
+import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 /**
  *
@@ -151,5 +152,10 @@ public class ParsingUtils {
         regex = regex.replaceAll("\\*", ".*"); // replace * with .*
         regex = regex.replaceAll("\\?", "."); // replace ? with .
         return regex;
+    }
+
+    public static XMLStreamException unexpectedAttribute(final XMLExtendedStreamReader reader, final int index) {
+        return new XMLStreamException(String.format("Unexpected attribute '%s' encountered", reader.getAttributeName(index)), reader.getLocation());
+
     }
 }

--- a/provisioning/src/main/resources/wildfly-feature-pack-1_1.xsd
+++ b/provisioning/src/main/resources/wildfly-feature-pack-1_1.xsd
@@ -17,7 +17,7 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="urn:wildfly:feature-pack:1.0"
+           xmlns="urn:wildfly:feature-pack:1.1"
            targetNamespace="urn:wildfly:feature-pack:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified">

--- a/provisioning/src/main/resources/wildfly-server-provisioning-1_1.xsd
+++ b/provisioning/src/main/resources/wildfly-server-provisioning-1_1.xsd
@@ -17,7 +17,7 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="urn:wildfly:server-provisioning:1.0"
+           xmlns="urn:wildfly:server-provisioning:1.1"
            targetNamespace="urn:wildfly:server-provisioning:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified">
@@ -30,9 +30,15 @@
                 <xs:element name="copy-artifacts" type="copy-artifacts-type" minOccurs="0" maxOccurs="1" />
             </xs:sequence>
             <xs:attribute name="copy-module-artifacts" type="xs:boolean" use="optional" />
-            <xs:attribute name="extract-schemas" type="xs:boolean" use="optional" />
+            <xs:attribute name="extract-schemas" type="xs:boolean" use="optional" default="false" />
+            <xs:attribute name="extract-schemas-groups" type="stringList" use="optional" default="org.jboss.as org.wildfly"/>
         </xs:complexType>
     </xs:element>
+
+    <xs:simpleType name="stringList">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
 
     <xs:complexType name="feature-packs-type">
         <xs:sequence>
@@ -149,5 +155,4 @@
         <xs:attribute name="pattern" type="xs:string" use="required" />
         <xs:attribute name="include" type="xs:boolean" use="required" />
     </xs:complexType>
-
 </xs:schema>


### PR DESCRIPTION
…n groupIds

- introduces 1.1 schema & parser for server-provisioning
- by default org.jboss.as & org.wildfly are configured as groups for extracting
- rework parser a bit to make it easier to version.
- ServerProvisioner was changed to use instance method instead of private static ones.