### PR TITLE
[WFBUILD-21] Use Woodstox as the StAX engine

### DIFF
--- a/feature-pack-build-maven-plugin/pom.xml
+++ b/feature-pack-build-maven-plugin/pom.xml
@@ -104,6 +104,14 @@
             <groupId>org.jboss</groupId>
             <artifactId>staxmapper</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>stax2-api</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         </version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>
         <version.org.apache.maven.plugin-tools>${version.plugin.plugin}</version.org.apache.maven.plugin-tools>
         <version.org.codehaus.plexus.plexus-utils>3.0.10</version.org.codehaus.plexus.plexus-utils>
+        <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
+        <version.org.codehaus.woodstox.woodstox-core-asl>4.4.1</version.org.codehaus.woodstox.woodstox-core-asl>
         <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
         <version.org.jboss.jandex>1.2.1.Final</version.org.jboss.jandex>
         <version.org.jboss.logging>3.1.4.GA</version.org.jboss.logging>
@@ -80,7 +82,7 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
-        <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
+        <version.org.jboss.staxmapper>1.2.0.Final</version.org.jboss.staxmapper>
     </properties>
 
     <modules>
@@ -279,6 +281,30 @@
                 <groupId>org.jboss</groupId>
                 <artifactId>staxmapper</artifactId>
                 <version>${version.org.jboss.staxmapper}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.woodstox</groupId>
+                <artifactId>woodstox-core-asl</artifactId>
+                <version>${version.org.codehaus.woodstox.woodstox-core-asl}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.stream</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.woodstox</groupId>
+                <artifactId>stax2-api</artifactId>
+                <version>${version.org.codehaus.woodstox.stax2-api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.stream</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- dependencies to annotations -->

--- a/provisioning/src/main/java/org/wildfly/build/util/xml/FormattingXMLStreamWriter.java
+++ b/provisioning/src/main/java/org/wildfly/build/util/xml/FormattingXMLStreamWriter.java
@@ -167,8 +167,8 @@ public final class FormattingXMLStreamWriter implements XMLStreamWriter, XMLStre
     }
 
     public void writeEndDocument() throws XMLStreamException {
-        delegate.writeEndDocument();
         nl();
+        delegate.writeEndDocument();
         state = END_DOCUMENT;
     }
 


### PR DESCRIPTION
* add dependencies to Woodstock artifacts in the maven plugin
* bump StaxMapper version to 1.2.0.Final
* in FormattingXMLStreamWriter.writeEndDocument(), add the new line
  before ending the document (which closes some underlying data
  structures).

JIRA: https://issues.jboss.org/browse/WFBUILD-21