### PR TITLE
WFBUILD-21/WFBUILD-22 - use woodstox stax engine & update deps / plugin versions

### DIFF
--- a/feature-pack-build-maven-plugin/pom.xml
+++ b/feature-pack-build-maven-plugin/pom.xml
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>${version.plugin.plugin}</version>
                 <configuration>
                     <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/feature-pack-build-maven-plugin/pom.xml
+++ b/feature-pack-build-maven-plugin/pom.xml
@@ -104,6 +104,14 @@
             <groupId>org.jboss</groupId>
             <artifactId>staxmapper</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>stax2-api</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
         <version.org.jboss.logging>3.3.0.Final</version.org.jboss.logging>
         <version.org.jboss.logging.processor>2.0.1.Final</version.org.jboss.logging.processor>
         <version.org.jboss.logmanager>2.0.4.Final</version.org.jboss.logmanager>
+        <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
+        <version.com.fasterxml.woodstox.woodstox-core>5.0.3</version.com.fasterxml.woodstox.woodstox-core>
 
         <!-- Surefire args -->
         <surefire.jpda.args/>
@@ -265,6 +267,30 @@
                 <groupId>org.jboss</groupId>
                 <artifactId>staxmapper</artifactId>
                 <version>${version.org.jboss.staxmapper}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${version.com.fasterxml.woodstox.woodstox-core}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.stream</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.woodstox</groupId>
+                <artifactId>stax2-api</artifactId>
+                <version>${version.org.codehaus.woodstox.stax2-api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.stream</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- dependencies to annotations -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>19</version>
+        <version>21</version>
     </parent>
 
     <groupId>org.wildfly.build</groupId>
@@ -59,20 +59,24 @@
             versions, add the artifactId or other qualifier to the property name.
             For example: <version.org.jboss.as.console>
          -->
-        <version.junit>4.11</version.junit>
+        <!-- overrides of jboss-parent-->
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <version.plugin.plugin>3.5</version.plugin.plugin>
+        <!-- end overrides  -->
 
-        <version.org.apache.maven.maven-core>3.1.0</version.org.apache.maven.maven-core>
-        <version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>3.2.0
-        </version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>
+        <version.junit>4.12</version.junit>
+
+        <version.org.apache.maven.maven-core>3.2.5</version.org.apache.maven.maven-core>
+        <version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>3.3.0</version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>
         <version.org.apache.maven.plugin-tools>${version.plugin.plugin}</version.org.apache.maven.plugin-tools>
         <version.org.apache.maven.plugins.maven-invoker-plugin>2.0.0</version.org.apache.maven.plugins.maven-invoker-plugin>
-        <version.org.codehaus.plexus.plexus-utils>3.0.10</version.org.codehaus.plexus.plexus-utils>
-        <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
-        <version.org.jboss.jandex>1.2.1.Final</version.org.jboss.jandex>
-        <version.org.jboss.logging>3.1.4.GA</version.org.jboss.logging>
-        <version.org.jboss.logging.processor>1.2.0.Final</version.org.jboss.logging.processor>
-        <version.org.jboss.logmanager>1.5.2.Final</version.org.jboss.logmanager>
-        <version.org.sonatype.aether>1.13.1</version.org.sonatype.aether>
+        <version.org.codehaus.plexus.plexus-utils>3.0.24</version.org.codehaus.plexus.plexus-utils>
+        <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
+        <version.org.jboss.jandex>2.0.3.Final</version.org.jboss.jandex>
+        <version.org.jboss.logging>3.3.0.Final</version.org.jboss.logging>
+        <version.org.jboss.logging.processor>2.0.1.Final</version.org.jboss.logging.processor>
+        <version.org.jboss.logmanager>2.0.4.Final</version.org.jboss.logmanager>
 
         <!-- Surefire args -->
         <surefire.jpda.args/>
@@ -80,8 +84,8 @@
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
-        <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
-        <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
+        <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
+        <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
     </properties>
 
     <modules>
@@ -96,25 +100,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-java</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>1.7</version>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -345,24 +330,6 @@
                 <groupId>org.eclipse.aether</groupId>
                 <artifactId>aether-transport-http</artifactId>
                 <version>${version.org.eclipse.aether}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.sonatype.aether</groupId>
-                <artifactId>aether-api</artifactId>
-                <version>${version.org.sonatype.aether}</version>
-                <scope>provided</scope>
-                <!-- Used in maven 3.0.x -->
-                <optional>true</optional>
-            </dependency>
-
-            <dependency>
-                <groupId>org.sonatype.aether</groupId>
-                <artifactId>aether-util</artifactId>
-                <version>${version.org.sonatype.aether}</version>
-                <scope>provided</scope>
-                <!-- Used in maven 3.0.x -->
-                <optional>true</optional>
             </dependency>
 
             <dependency>

--- a/provisioning-maven-plugin/pom.xml
+++ b/provisioning-maven-plugin/pom.xml
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>${version.plugin.plugin}</version>
                 <configuration>
                     <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/provisioning-maven-plugin/src/it/it-minimal/dist/it-expected/standalone/configuration/standalone.xml
+++ b/provisioning-maven-plugin/src/it/it-minimal/dist/it-expected/standalone/configuration/standalone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 
 <server xmlns="urn:jboss:domain:4.0">
     <extensions>

--- a/provisioning-maven-plugin/src/it/it-minimal/feature-pack/it-expected/wildfly-feature-pack.xml
+++ b/provisioning-maven-plugin/src/it/it-minimal/feature-pack/it-expected/wildfly-feature-pack.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 
 <feature-pack xmlns="urn:wildfly:feature-pack:1.1">
     <config>

--- a/provisioning-maven-plugin/src/it/it-minimal/verify.groovy
+++ b/provisioning-maven-plugin/src/it/it-minimal/verify.groovy
@@ -1,4 +1,3 @@
-import org.apache.commons.io.FileUtils;
 
 /*
  * Copyright 2016 Red Hat, Inc.
@@ -39,6 +38,6 @@ public class Assertions {
         File actual = new File(actualRootDir, path)
         assert expected.exists()
         assert actual.exists()
-        assert org.codehaus.plexus.util.FileUtils.contentEquals(expected, actual)
+        assert org.apache.commons.io.FileUtils.contentEqualsIgnoreEOL(expected, actual, "utf-8")
     }
 }

--- a/provisioning-maven-plugin/src/it/it-resources-dir/dist/it-expected/standalone/configuration/standalone.xml
+++ b/provisioning-maven-plugin/src/it/it-resources-dir/dist/it-expected/standalone/configuration/standalone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 
 <server xmlns="urn:jboss:domain:4.0">
     <extensions>

--- a/provisioning-maven-plugin/src/it/it-resources-dir/feature-pack/it-expected/wildfly-feature-pack.xml
+++ b/provisioning-maven-plugin/src/it/it-resources-dir/feature-pack/it-expected/wildfly-feature-pack.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 
 <feature-pack xmlns="urn:wildfly:feature-pack:1.1">
     <config>

--- a/provisioning-maven-plugin/src/it/it-resources-dir/verify.groovy
+++ b/provisioning-maven-plugin/src/it/it-resources-dir/verify.groovy
@@ -1,5 +1,3 @@
-import org.apache.commons.io.FileUtils;
-
 /*
  * Copyright 2016 Red Hat, Inc.
  *
@@ -39,6 +37,6 @@ public class Assertions {
         File actual = new File(actualRootDir, path)
         assert expected.exists()
         assert actual.exists()
-        assert org.codehaus.plexus.util.FileUtils.contentEquals(expected, actual)
+        assert org.apache.commons.io.FileUtils.contentEqualsIgnoreEOL(expected, actual, "utf-8")
     }
 }

--- a/provisioning/pom.xml
+++ b/provisioning/pom.xml
@@ -79,14 +79,7 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
-            <artifactId>aether-api</artifactId>
-            <scope>provided</scope>
-            <!-- Used in maven 3.0.x -->
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-util</artifactId>
             <scope>provided</scope>
             <!-- Used in maven 3.0.x -->

--- a/provisioning/src/main/java/org/wildfly/build/util/ZipEntryInputStreamSource.java
+++ b/provisioning/src/main/java/org/wildfly/build/util/ZipEntryInputStreamSource.java
@@ -55,7 +55,7 @@ public class ZipEntryInputStreamSource implements InputStreamSource {
         private final ZipFile zipFile;
         private final InputStream zipEntryInputStream;
 
-        public ZipEntryInputStream(ZipFile zipFile, InputStream zipEntryInputStream) {
+        ZipEntryInputStream(ZipFile zipFile, InputStream zipEntryInputStream) {
             this.zipFile = zipFile;
             this.zipEntryInputStream = zipEntryInputStream;
         }

--- a/provisioning/src/main/java/org/wildfly/build/util/xml/FormattingXMLStreamWriter.java
+++ b/provisioning/src/main/java/org/wildfly/build/util/xml/FormattingXMLStreamWriter.java
@@ -167,8 +167,8 @@ public final class FormattingXMLStreamWriter implements XMLStreamWriter, XMLStre
     }
 
     public void writeEndDocument() throws XMLStreamException {
-        delegate.writeEndDocument();
         nl();
+        delegate.writeEndDocument();
         state = END_DOCUMENT;
     }
 


### PR DESCRIPTION
superceeds #35 

- add dependencies to Woodstock artifacts in the maven plugin
- in FormattingXMLStreamWriter.writeEndDocument(), add the new line
  before ending the document (which closes some underlying data  structures).
- WFBUILD-22 upgrade jandex to 2.0.3.Final
- update jboss-parent to 21 to aid with work on JDK9
- update staxmapper to 1.3
- update plugin versions to latest
- unify usage of aether
- fix build IT on windows