### PR TITLE
Provide for server-provisioning to create overlays.

### DIFF
--- a/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/plugin/MavenProjectArtifactResolver.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/plugin/MavenProjectArtifactResolver.java
@@ -38,10 +38,19 @@ public class MavenProjectArtifactResolver implements ArtifactResolver {
             sb.append(artifact.getGACE().getGroupId());
             sb.append(':');
             sb.append(artifact.getGACE().getArtifactId());
+            String extension = artifact.getGACE().getExtension();
             if (artifact.getGACE().getClassifier() != null && !artifact.getGACE().getClassifier().isEmpty()) {
-                artifactMap.put(sb.append("::").append(artifact.getGACE().getClassifier()).toString(), artifact);
+                if ( extension == null || extension.equals("jar")) {
+                    artifactMap.put(sb.append("::").append(artifact.getGACE().getClassifier()).toString(), artifact);
+                } else {
+                    artifactMap.put(sb.append(":").append(extension).append(":").append(artifact.getGACE().getClassifier()).toString(), artifact);
+                }
             } else {
-                artifactMap.put(sb.toString(), artifact);
+                if ( extension == null || extension.equals("jar")) {
+                    artifactMap.put(sb.toString(), artifact);
+                } else {
+                    artifactMap.put(sb.append(":").append(extension).toString(), artifact);
+                }
             }
         }
     }

--- a/provisioning-standalone/src/main/java/org/wildfly/build/provisioning/ProvisionCommand.java
+++ b/provisioning-standalone/src/main/java/org/wildfly/build/provisioning/ProvisionCommand.java
@@ -61,7 +61,7 @@ public class ProvisionCommand {
             }
             // provision the server
             final File outputDir = new File(buildDir, "wildfly");
-            ServerProvisioner.build(serverProvisioningDescription, outputDir, aetherArtifactFileResolver, overrideArtifactResolver);
+            ServerProvisioner.build(serverProvisioningDescription, outputDir, false, aetherArtifactFileResolver, overrideArtifactResolver);
             System.out.print("Server provisioning at "+outputDir+" complete.");
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifact.java
+++ b/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifact.java
@@ -30,13 +30,20 @@ public class CopyArtifact {
     private final String artifact;
     private final String toLocation;
     private final boolean extract;
+    private final String fromLocation;
     private final List<FileFilter> filters = new ArrayList<>();
 
 
-    public CopyArtifact(String artifact, String toLocation, boolean extract) {
+    public CopyArtifact(String artifact, String toLocation, boolean extract, String fromLocation) {
         this.artifact = artifact;
         this.toLocation = toLocation;
-        this.extract = extract;
+        this.extract = extract || fromLocation != null;
+        if ( fromLocation != null ) {
+            if ( ! fromLocation.endsWith( "/" ) ) {
+                fromLocation = fromLocation + "/";
+            }
+        }
+        this.fromLocation = fromLocation;
     }
 
     public String getArtifact() {
@@ -63,4 +70,17 @@ public class CopyArtifact {
         }
         return true; //default include
     }
+
+    public String relocatedPath(final String path) {
+        if ( this.fromLocation == null ) {
+            return path;
+        }
+
+        if ( path.startsWith( this.fromLocation ) ) {
+            return path.substring( this.fromLocation.length() );
+        }
+
+        return null;
+    }
+
 }

--- a/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifactsModelParser10.java
+++ b/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifactsModelParser10.java
@@ -79,6 +79,7 @@ public class CopyArtifactsModelParser10 {
         UNKNOWN(null),
         ARTIFACT("artifact"),
         TO_LOCATION("to-location"),
+        FROM_LOCATION("from-location"),
         EXTRACT("extract"),
         ;
 
@@ -88,6 +89,7 @@ public class CopyArtifactsModelParser10 {
             Map<String, Attribute> attributesMap = new HashMap<>();
             attributesMap.put(ARTIFACT.getLocalName(), ARTIFACT);
             attributesMap.put(TO_LOCATION.getLocalName(), TO_LOCATION);
+            attributesMap.put(FROM_LOCATION.getLocalName(), FROM_LOCATION);
             attributesMap.put(EXTRACT.getLocalName(), EXTRACT);
             attributes = attributesMap;
         }
@@ -152,7 +154,8 @@ public class CopyArtifactsModelParser10 {
 
     private void parseCopyArtifact(XMLStreamReader reader, final List<CopyArtifact> result) throws XMLStreamException {
         String artifact = null;
-        String location = null;
+        String toLocation = null;
+        String fromLocation = null;
         boolean extract = false;
         final Set<Attribute> required = EnumSet.of(Attribute.ARTIFACT, Attribute.TO_LOCATION);
         final int count = reader.getAttributeCount();
@@ -164,7 +167,10 @@ public class CopyArtifactsModelParser10 {
                     artifact = propertyReplacer.replaceProperties(reader.getAttributeValue(i));
                     break;
                 case TO_LOCATION:
-                    location = propertyReplacer.replaceProperties(reader.getAttributeValue(i));
+                    toLocation = propertyReplacer.replaceProperties(reader.getAttributeValue(i));
+                    break;
+                case FROM_LOCATION:
+                    fromLocation = propertyReplacer.replaceProperties(reader.getAttributeValue(i));
                     break;
                 case EXTRACT:
                     extract = Boolean.parseBoolean(propertyReplacer.replaceProperties(reader.getAttributeValue(i)));
@@ -177,7 +183,7 @@ public class CopyArtifactsModelParser10 {
             throw ParsingUtils.missingAttributes(reader.getLocation(), required);
         }
 
-        CopyArtifact copyArtifact = new CopyArtifact(artifact, location, extract);
+        CopyArtifact copyArtifact = new CopyArtifact(artifact, toLocation, extract, fromLocation);
         result.add(copyArtifact);
         while (reader.hasNext()) {
             switch (reader.nextTag()) {

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser.java
@@ -32,6 +32,7 @@ public class ServerProvisioningDescriptionModelParser {
 
     private static final QName ROOT_1_0 = new QName(ServerProvisioningDescriptionModelParser10.NAMESPACE_1_0, Element.SERVER_PROVISIONING.getLocalName());
     private static final QName ROOT_1_1 = new QName(ServerProvisioningDescriptionModelParser11.NAMESPACE_1_1, Element.SERVER_PROVISIONING.getLocalName());
+    private static final QName ROOT_1_2 = new QName(ServerProvisioningDescriptionModelParser12.NAMESPACE_1_2, Element.SERVER_PROVISIONING.getLocalName());
 
     private static final XMLInputFactory INPUT_FACTORY = XMLInputFactory.newInstance();
 
@@ -41,6 +42,7 @@ public class ServerProvisioningDescriptionModelParser {
         mapper = XMLMapper.Factory.create();
         mapper.registerRootElement(ROOT_1_0, new ServerProvisioningDescriptionModelParser10(properties));
         mapper.registerRootElement(ROOT_1_1, new ServerProvisioningDescriptionModelParser11(properties));
+        mapper.registerRootElement(ROOT_1_2, new ServerProvisioningDescriptionModelParser12(properties));
     }
 
     public ServerProvisioningDescription parse(final InputStream input) throws XMLStreamException {

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser12.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/model/ServerProvisioningDescriptionModelParser12.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.build.provisioning.model;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.wildfly.build.util.PropertyResolver;
+import org.wildfly.build.util.xml.ParsingUtils;
+
+/**
+ * Parses the distribution build config file, i.e. the config file that is
+ * used to create a wildfly distribution.
+ *
+ * @author Tomaz Cerar
+ */
+class ServerProvisioningDescriptionModelParser12 extends ServerProvisioningDescriptionModelParser11 {
+
+    public static final String NAMESPACE_1_2 = "urn:wildfly:server-provisioning:1.2";
+
+    ServerProvisioningDescriptionModelParser12(PropertyResolver resolver) {
+        super(resolver);
+    }
+
+    /*
+    we only override this method, for now only change new EXTRACT_SCHEMAS_GROUPS attribute
+     */
+    @Override
+    public void readElement(final XMLExtendedStreamReader reader, final ServerProvisioningDescription result) throws XMLStreamException {
+        for (int i = 0; i < reader.getAttributeCount(); i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            switch (attribute) {
+                case COPY_MODULE_ARTIFACTS:
+                    result.setCopyModuleArtifacts(Boolean.parseBoolean(reader.getAttributeValue(i)));
+                    break;
+                case EXTRACT_SCHEMAS:
+                    result.setExtractSchemas(Boolean.parseBoolean(reader.getAttributeValue(i)));
+                    break;
+                case EXTRACT_SCHEMAS_GROUPS:
+                    result.setExtractSchemasGroups(reader.getAttributeValue(i));
+                    break;
+                case EXCLUDE_DEPENDENCIES:
+                    result.setExcludeDependencies(Boolean.parseBoolean(reader.getAttributeValue(i)));
+                    break;
+                default:
+                    throw ParsingUtils.unexpectedAttribute(reader, i);
+            }
+        }
+
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case XMLStreamConstants.END_ELEMENT: {
+                    return;
+                }
+                case XMLStreamConstants.START_ELEMENT: {
+                    final Element element = Element.of(reader.getLocalName());
+
+                    switch (element) {
+                        case FEATURE_PACKS:
+                            parseFeaturePacks(reader, result);
+                            break;
+                        case VERSION_OVERRIDES:
+                            parseVersionOverrides(reader, result);
+                            break;
+                        case COPY_ARTIFACTS:
+                            copyArtifactsModelParser.parseCopyArtifacts(reader, result.getCopyArtifacts());
+                            break;
+                        default:
+                            throw new XMLStreamException(String.format("Unknown element: '%s', elementName: %s, localName: %s", element, reader.getName(), reader.getLocalName()), reader.getLocation());
+                            //throw ParsingUtils.unexpectedContent(reader);
+                    }
+                    break;
+                }
+                default: {
+                    throw ParsingUtils.unexpectedContent(reader);
+                }
+            }
+        }
+        throw ParsingUtils.endOfDocument(reader.getLocation());
+    }
+
+}

--- a/provisioning/src/main/resources/wildfly-server-provisioning-1_2.xsd
+++ b/provisioning/src/main/resources/wildfly-server-provisioning-1_2.xsd
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2014 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:wildfly:server-provisioning:1.1"
+           targetNamespace="urn:wildfly:server-provisioning:1.2"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:element name="server-provisioning">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="feature-packs" type="feature-packs-type" minOccurs="0" maxOccurs="1" />
+                <xs:element name="version-overrides" type="version-overrides-type" minOccurs="0" maxOccurs="1" />
+                <xs:element name="copy-artifacts" type="copy-artifacts-type" minOccurs="0" maxOccurs="1" />
+            </xs:sequence>
+            <xs:attribute name="copy-module-artifacts" type="xs:boolean" use="optional" />
+            <xs:attribute name="extract-schemas" type="xs:boolean" use="optional" default="false" />
+            <xs:attribute name="extract-schemas-groups" type="stringList" use="optional" default="org.jboss.as org.wildfly"/>
+            <xs:attribute name="exclude-dependencies" type="xs:boolean" use="optional" default="false" />
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="stringList">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+
+    <xs:complexType name="feature-packs-type">
+        <xs:sequence>
+            <xs:element name="feature-pack" type="feature-pack-type" maxOccurs="unbounded" minOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="feature-pack-type">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="subsystems" type="feature-pack-subsystems-type" />
+                <xs:element name="config" type="feature-pack-config-type" />
+            </xs:choice>
+            <xs:element name="modules" type="feature-pack-modules-type" minOccurs="0" maxOccurs="1" />
+            <xs:element name="contents" type="feature-pack-contents-type" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="groupId" type="xs:string" use="required"/>
+        <xs:attribute name="artifactId" type="xs:string" use="required"/>
+        <xs:attribute name="classifier" type="xs:string" use="optional"/>
+        <xs:attribute name="extension" type="xs:string" use="optional"/>
+        <xs:attribute name="version" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="feature-pack-modules-type">
+        <xs:sequence>
+            <xs:element name="filter" type="feature-pack-module-filter-type" maxOccurs="unbounded" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="include" use="optional" type="xs:boolean" default="true" />
+    </xs:complexType>
+    <xs:complexType name="feature-pack-module-filter-type">
+        <xs:attribute name="pattern" type="xs:string" use="required" />
+        <xs:attribute name="include" type="xs:boolean" use="required" />
+        <xs:attribute name="transitive" type="xs:boolean" use="optional" default="true" />
+    </xs:complexType>
+
+    <xs:complexType name="feature-pack-config-type">
+        <xs:sequence>
+            <xs:element name="standalone" type="feature-pack-config-file-type" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="domain" type="feature-pack-config-file-type" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="host" type="feature-pack-config-file-type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="feature-pack-config-file-type">
+        <xs:sequence>
+            <xs:element name="property" type="feature-pack-config-file-property-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="subsystems" type="feature-pack-config-file-subsystems-type" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="output-file" use="required" type="xs:string" />
+        <xs:attribute name="use-template" use="optional" type="xs:boolean" />
+    </xs:complexType>
+    <xs:complexType name="feature-pack-config-file-property-type">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="feature-pack-config-file-subsystems-type">
+        <xs:sequence>
+            <xs:element name="subsystem" type="feature-pack-config-file-subsystem-type" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="feature-pack-config-file-subsystem-type">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="supplement" type="xs:string" use="optional"/>
+                <xs:attribute name="include-if-set" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="feature-pack-contents-type">
+        <xs:sequence>
+            <xs:element name="filter" type="filter-type" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="include" use="optional" type="xs:boolean" default="true" />
+    </xs:complexType>
+
+    <xs:complexType name="feature-pack-subsystems-type">
+        <xs:sequence>
+            <xs:element name="subsystem" type="feature-pack-subsystem-type" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="feature-pack-subsystem-type">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="transitive" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="version-overrides-type">
+        <xs:sequence>
+            <xs:element name="version-override" type="artifact-type" maxOccurs="unbounded" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="artifact-type">
+        <xs:attribute name="groupId" type="xs:string" use="required"/>
+        <xs:attribute name="artifactId" type="xs:string" use="required"/>
+        <xs:attribute name="classifier" type="xs:string" use="optional"/>
+        <xs:attribute name="extension" type="xs:string" use="optional"/>
+        <xs:attribute name="version" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="copy-artifacts-type">
+        <xs:sequence>
+            <xs:element name="copy-artifact" type="copy-artifact-type" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="copy-artifact-type">
+        <xs:sequence>
+            <xs:element name="filter" type="filter-type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="artifact" />
+        <xs:attribute name="to-location" />
+        <xs:attribute name="extract" use="optional" default="false" />
+        <xs:attribute name="from-location" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="filter-type">
+        <xs:attribute name="pattern" type="xs:string" use="required" />
+        <xs:attribute name="include" type="xs:boolean" use="required" />
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION

* Add boolean overlay parameter (and Mojo configuration) to
  indicate the desire to create an overlay instead of a provisioned
  server.

  When running in overlay mode, all dependencies are excluded, and
  only the root items & feature-packs from the service-provisioning.xml are
  processed.

  Additionally, configuration is not processed, no standalone or domain
  XML files are emitted, as it is assumed the user of an overlay will
  manually adjust their own existing XML files. An overlay should not
  trample existing configuration.

* Add from-location attribute to <copy-artifact> to allow extracting
  portions of artifacts. Implies extract=true.

* From the Mojo, include the MavenArtifactResolver so that other
  arbitrary artifacts can be resolved from the pom.xml driving the
  server-provisioning, not just feature-pack resolution.

* Within the MavenArtifactResolver, provide support for non-jar
  extension types when mapping resolvable artifacts.