### PR TITLE
Changes related to the Bean Validation/HV upgrade

### DIFF
--- a/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/featurepack/FeaturePackBuilder.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/featurepack/FeaturePackBuilder.java
@@ -195,11 +195,18 @@ public class FeaturePackBuilder {
     private static void processVersions(FeaturePackDescription featurePackDescription, ArtifactResolver artifactResolver, Map<Artifact.GACE, String> artifactVersionMap) {
         // resolve copy-artifact versions and add to map
         for (CopyArtifact copyArtifact : featurePackDescription.getCopyArtifacts()) {
-            final Artifact artifact = artifactResolver.getArtifact(copyArtifact.getArtifact());
-            if(artifact == null) {
-                throw new RuntimeException("Could not resolve artifact for copy artifact " + copyArtifact.getArtifact());
+            CopyArtifact.ArtifactName artifactName = copyArtifact.getArtifact();
+
+            final Artifact artifact;
+            if (artifactName.hasVersion()) {
+                artifact = artifactName.getArtifact();
+            } else {
+                artifact = artifactResolver.getArtifact(artifactName.getArtifactCoords());
+                if(artifact == null) {
+                    throw new RuntimeException("Could not resolve artifact for copy artifact " + copyArtifact.getArtifact());
+                }
+                artifactVersionMap.put(artifact.getGACE(), artifact.getVersion());
             }
-            artifactVersionMap.put(artifact.getGACE(), artifact.getVersion());
         }
         // fill feature pack description versions
         for (Map.Entry<Artifact.GACE, String> mapEntry : artifactVersionMap.entrySet()) {

--- a/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/featurepack/FeaturePackBuilder.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/featurepack/FeaturePackBuilder.java
@@ -34,6 +34,7 @@ import org.wildfly.build.pack.model.ModuleIdentifier;
 import org.wildfly.build.util.FileUtils;
 import org.wildfly.build.util.ModuleParseResult;
 import org.wildfly.build.util.ModuleParser;
+import org.wildfly.build.util.PropertyResolver;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
@@ -71,7 +72,7 @@ public class FeaturePackBuilder {
 
     private static final Logger logger = Logger.getLogger(FeaturePackBuilder.class);
 
-    public static void build(FeaturePackBuild build, File serverDirectory, ArtifactResolver artifactResolver, ArtifactFileResolver artifactFileResolver) {
+    public static void build(FeaturePackBuild build, File serverDirectory, PropertyResolver propertyResolver, ArtifactResolver artifactResolver, ArtifactFileResolver artifactFileResolver) {
 
         //List of errors that were encountered. These will be reported at the end so they are all reported in one go.
         final List<String> errors = new ArrayList<>();
@@ -79,8 +80,8 @@ public class FeaturePackBuilder {
         final Map<Artifact.GACE, String> artifactVersionMap = new HashMap<>();
         final FeaturePackDescription featurePackDescription = new FeaturePackDescription(build.getDependencies(), build.getConfig(), build.getCopyArtifacts(), build.getFilePermissions());
         try {
-            processDependencies(build.getDependencies(), knownModules, new HashSet<String>(), artifactResolver, artifactFileResolver, artifactVersionMap);
-            processModulesDirectory(knownModules, serverDirectory, artifactResolver, artifactVersionMap, errors);
+            processDependencies(build.getDependencies(), knownModules, new HashSet<String>(), propertyResolver, artifactResolver, artifactFileResolver, artifactVersionMap);
+            processModulesDirectory(knownModules, serverDirectory, propertyResolver, artifactResolver, artifactVersionMap, errors);
             processVersions(featurePackDescription, artifactResolver, artifactVersionMap);
             processContentsDirectory(build, serverDirectory);
             writeFeaturePackXml(featurePackDescription, serverDirectory);
@@ -99,7 +100,7 @@ public class FeaturePackBuilder {
         }
     }
 
-    private static void processDependencies(List<String> dependencies, Set<ModuleIdentifier> knownModules, Set<String> featurePacksProcessed, ArtifactResolver buildArtifactResolver, ArtifactFileResolver artifactFileResolver, final Map<Artifact.GACE, String> artifactVersionMap) {
+    private static void processDependencies(List<String> dependencies, Set<ModuleIdentifier> knownModules, Set<String> featurePacksProcessed, PropertyResolver propertyResolver, ArtifactResolver buildArtifactResolver, ArtifactFileResolver artifactFileResolver, final Map<Artifact.GACE, String> artifactVersionMap) {
         for (String dependency : dependencies) {
             if (!featurePacksProcessed.add(dependency)) {
                 continue;
@@ -112,7 +113,7 @@ public class FeaturePackBuilder {
                 throw new RuntimeException("Could not find artifact for " + dependency);
             }
             // load the dependency feature pack
-            FeaturePack dependencyFeaturePack = FeaturePackFactory.createPack(dependencyArtifact, artifactFileResolver, new FeaturePackArtifactResolver(Collections.<Artifact>emptyList()));
+            FeaturePack dependencyFeaturePack = FeaturePackFactory.createPack(dependencyArtifact, propertyResolver, artifactFileResolver, new FeaturePackArtifactResolver(Collections.<Artifact>emptyList()));
             // put its artifact to the version map
             artifactVersionMap.put(dependencyFeaturePack.getArtifact().getGACE(), dependencyFeaturePack.getArtifact().getVersion());
             // process it
@@ -137,9 +138,12 @@ public class FeaturePackBuilder {
         }
     }
 
-    private static void processModulesDirectory(Set<ModuleIdentifier> packProvidedModules, File serverDirectory, final ArtifactResolver artifactResolver, final Map<Artifact.GACE, String> artifactVersionMap,  final List<String> errors) throws IOException {
+    private static void processModulesDirectory(Set<ModuleIdentifier> packProvidedModules, File serverDirectory,
+            final PropertyResolver propertyResolver, final ArtifactResolver artifactResolver,
+            final Map<Artifact.GACE, String> artifactVersionMap, final List<String> errors) throws IOException {
         final Path modulesDir = Paths.get(new File(serverDirectory, Locations.MODULES).getAbsolutePath());
         if (Files.exists(modulesDir)) {
+            final ModuleParser moduleParser = new ModuleParser(propertyResolver);
             final HashSet<ModuleIdentifier> knownModules = new HashSet<>(packProvidedModules);
             final Map<ModuleIdentifier, Set<ModuleIdentifier>> requiredDepds = new HashMap<>();
             Files.walkFileTree(modulesDir, new SimpleFileVisitor<Path>() {
@@ -149,7 +153,7 @@ public class FeaturePackBuilder {
                         return FileVisitResult.CONTINUE;
                     }
                     try {
-                        ModuleParseResult result = ModuleParser.parse(file);
+                        ModuleParseResult result = moduleParser.parse(file);
                         knownModules.add(result.getIdentifier());
                         for (ModuleParseResult.ArtifactName artifactName : result.getArtifacts()) {
 

--- a/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/plugin/FeaturePackBuildMojo.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/wildfly/build/plugin/FeaturePackBuildMojo.java
@@ -35,6 +35,7 @@ import org.wildfly.build.featurepack.model.FeaturePackBuild;
 import org.wildfly.build.featurepack.model.FeaturePackBuildModelParser;
 import org.wildfly.build.util.FileUtils;
 import org.wildfly.build.util.MapPropertyResolver;
+import org.wildfly.build.util.PropertyResolver;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -131,9 +132,11 @@ public class FeaturePackBuildMojo extends AbstractMojo {
             properties.putAll(project.getProperties());
             properties.putAll(System.getProperties());
             properties.put("project.version", project.getVersion()); //TODO: figure out the correct way to do this
-            final FeaturePackBuild build = new FeaturePackBuildModelParser(new MapPropertyResolver(properties)).parse(configStream);
+            PropertyResolver propertyResolver = new MapPropertyResolver(properties);
+
+            final FeaturePackBuild build = new FeaturePackBuildModelParser(propertyResolver).parse(configStream);
             File target = new File(buildName, serverName);
-            FeaturePackBuilder.build(build, target, new MavenProjectArtifactResolver(project), new AetherArtifactFileResolver(repoSystem, repoSession, remoteRepos));
+            FeaturePackBuilder.build(build, target, propertyResolver, new MavenProjectArtifactResolver(project), new AetherArtifactFileResolver(repoSystem, repoSession, remoteRepos));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/provisioning-maven-plugin/src/main/java/org/wildfly/build/plugin/ServerProvisioningMojo.java
+++ b/provisioning-maven-plugin/src/main/java/org/wildfly/build/plugin/ServerProvisioningMojo.java
@@ -37,6 +37,7 @@ import org.wildfly.build.provisioning.model.ServerProvisioningDescription;
 import org.wildfly.build.provisioning.model.ServerProvisioningDescriptionModelParser;
 import org.wildfly.build.util.MapPropertyResolver;
 import org.wildfly.build.util.PropertiesBasedArtifactResolver;
+import org.wildfly.build.util.PropertyResolver;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -118,7 +119,9 @@ public class ServerProvisioningMojo extends AbstractMojo {
             properties.putAll(System.getProperties());
             properties.put("project.version", project.getVersion()); //TODO: figure out the correct way to do this
 
-            final ServerProvisioningDescription serverProvisioningDescription = new ServerProvisioningDescriptionModelParser(new MapPropertyResolver(properties)).parse(configStream);
+            PropertyResolver propertyResolver = new MapPropertyResolver(properties);
+
+            final ServerProvisioningDescription serverProvisioningDescription = new ServerProvisioningDescriptionModelParser(propertyResolver).parse(configStream);
             AetherArtifactFileResolver aetherArtifactFileResolver = new AetherArtifactFileResolver(repoSystem, repoSession, remoteRepos);
             ArtifactResolver overrideArtifactResolver = new FeaturePackArtifactResolver(serverProvisioningDescription.getVersionOverrides());
             if(allowMavenVersionOverrides) {
@@ -129,7 +132,7 @@ public class ServerProvisioningMojo extends AbstractMojo {
             }
 
 
-            ServerProvisioner.build(serverProvisioningDescription, new File(buildName, serverName), overlay, aetherArtifactFileResolver, overrideArtifactResolver);
+            ServerProvisioner.build(serverProvisioningDescription, new File(buildName, serverName), overlay, propertyResolver, aetherArtifactFileResolver, overrideArtifactResolver);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifact.java
+++ b/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifact.java
@@ -18,6 +18,8 @@ package org.wildfly.build.common.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.wildfly.build.pack.model.Artifact;
+
 /**
  * Represents an artifact that is copies into a specific location in the final
  * build.
@@ -27,14 +29,14 @@ import java.util.List;
  */
 public class CopyArtifact {
 
-    private final String artifact;
+    private final CopyArtifact.ArtifactName artifact;
     private final String toLocation;
     private final boolean extract;
     private final String fromLocation;
     private final List<FileFilter> filters = new ArrayList<>();
 
 
-    public CopyArtifact(String artifact, String toLocation, boolean extract, String fromLocation) {
+    public CopyArtifact(ArtifactName artifact, String toLocation, boolean extract, String fromLocation) {
         this.artifact = artifact;
         this.toLocation = toLocation;
         this.extract = extract || fromLocation != null;
@@ -46,7 +48,7 @@ public class CopyArtifact {
         this.fromLocation = fromLocation;
     }
 
-    public String getArtifact() {
+    public ArtifactName getArtifact() {
         return artifact;
     }
 
@@ -83,4 +85,44 @@ public class CopyArtifact {
         return null;
     }
 
+    public static class ArtifactName {
+
+        private final String artifactCoords;
+
+        public ArtifactName(String artifactCoords) {
+            this.artifactCoords = artifactCoords;
+        }
+
+        public String getArtifactCoords() {
+            return artifactCoords;
+        }
+
+        @Override
+        public String toString() {
+            return artifactCoords;
+        }
+
+        public boolean hasVersion() {
+            String[] parts = artifactCoords.split(":");
+            if(parts.length > 2) {
+                String version = parts[2];
+                if(version != null && !version.isEmpty()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public Artifact getArtifact() {
+            if(!hasVersion()) {
+                throw new IllegalStateException("can only be called when version is hard coded");
+            }
+            String[] parts = getArtifactCoords().split(":");
+            if(parts.length == 3) {
+                return new Artifact(parts[0], parts[1], null, "jar", parts[2]);
+            } else {
+                return new Artifact(parts[0], parts[1], parts[3], "jar", parts[2]);
+            }
+        }
+    }
 }

--- a/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifactsModelParser10.java
+++ b/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifactsModelParser10.java
@@ -153,7 +153,7 @@ public class CopyArtifactsModelParser10 {
     }
 
     private void parseCopyArtifact(XMLStreamReader reader, final List<CopyArtifact> result) throws XMLStreamException {
-        String artifact = null;
+        CopyArtifact.ArtifactName artifact = null;
         String toLocation = null;
         String fromLocation = null;
         boolean extract = false;
@@ -164,7 +164,7 @@ public class CopyArtifactsModelParser10 {
             required.remove(attribute);
             switch (attribute) {
                 case ARTIFACT:
-                    artifact = propertyReplacer.replaceProperties(reader.getAttributeValue(i));
+                    artifact = new CopyArtifact.ArtifactName(propertyReplacer.replaceProperties(reader.getAttributeValue(i)));
                     break;
                 case TO_LOCATION:
                     toLocation = propertyReplacer.replaceProperties(reader.getAttributeValue(i));

--- a/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifactsXMLWriter10.java
+++ b/provisioning/src/main/java/org/wildfly/build/common/model/CopyArtifactsXMLWriter10.java
@@ -53,7 +53,7 @@ public class CopyArtifactsXMLWriter10 {
                 FileFilterXMLWriter10.INSTANCE.write(fileFilter, copyArtifactElementNode);
             }
         }
-        copyArtifactElementNode.addAttribute(Attribute.ARTIFACT.getLocalName(), new AttributeValue(copyArtifact.getArtifact()));
+        copyArtifactElementNode.addAttribute(Attribute.ARTIFACT.getLocalName(), new AttributeValue(copyArtifact.getArtifact().getArtifactCoords()));
         copyArtifactElementNode.addAttribute(Attribute.TO_LOCATION.getLocalName(), new AttributeValue(copyArtifact.getToLocation()));
         if (copyArtifact.isExtract()) {
             copyArtifactElementNode.addAttribute(Attribute.EXTRACT.getLocalName(), new AttributeValue(Boolean.toString(copyArtifact.isExtract())));

--- a/provisioning/src/main/java/org/wildfly/build/pack/model/FeaturePack.java
+++ b/provisioning/src/main/java/org/wildfly/build/pack/model/FeaturePack.java
@@ -22,6 +22,7 @@ import org.wildfly.build.common.model.ConfigFile;
 import org.wildfly.build.configassembly.SubsystemConfig;
 import org.wildfly.build.util.ModuleParseResult;
 import org.wildfly.build.util.ModuleParser;
+import org.wildfly.build.util.PropertyResolver;
 import org.wildfly.build.util.ZipFileSubsystemInputStreamSources;
 
 import javax.xml.stream.XMLStreamException;
@@ -59,9 +60,10 @@ public class FeaturePack {
     private final SortedSet<String> modulesFiles;
     private final List<String> contentFiles;
     private final List<FeaturePack> dependencies;
+    private final ModuleParser moduleParser;
     private final ArtifactResolver artifactResolver;
 
-    public FeaturePack(File featurePackFile, Artifact featurePackArtifact, FeaturePackDescription description, List<FeaturePack> dependencies, ArtifactResolver artifactResolver, List<String> configurationFiles, List<String> modulesFiles, List<String> contentFiles) {
+    public FeaturePack(File featurePackFile, Artifact featurePackArtifact, FeaturePackDescription description, List<FeaturePack> dependencies, PropertyResolver propertyResolver, ArtifactResolver artifactResolver, List<String> configurationFiles, List<String> modulesFiles, List<String> contentFiles) {
         this.featurePackFile = featurePackFile;
         this.featurePackArtifact = featurePackArtifact;
         this.description = description;
@@ -70,6 +72,7 @@ public class FeaturePack {
         this.configurationFiles = Collections.unmodifiableList(configurationFiles);
         this.modulesFiles = Collections.unmodifiableSortedSet(new TreeSet<String>(modulesFiles));
         this.contentFiles = Collections.unmodifiableList(contentFiles);
+        this.moduleParser = new ModuleParser(propertyResolver);
     }
 
     public FeaturePackDescription getDescription() {
@@ -119,7 +122,7 @@ public class FeaturePack {
                     if (moduleFile.endsWith(MODULE_XML_ENTRY_NAME_SUFIX)) {
                         ZipEntry entry = jar.getEntry(moduleFile);
                         // parse the module file
-                        ModuleParseResult moduleParseResult = ModuleParser.parse(jar.getInputStream(entry));
+                        ModuleParseResult moduleParseResult = moduleParser.parse(jar.getInputStream(entry));
                         featurePackModules.put(moduleParseResult.getIdentifier(), new Module(this, moduleFile, moduleParseResult));
                     }
                 }

--- a/provisioning/src/main/java/org/wildfly/build/pack/model/FeaturePackFactory.java
+++ b/provisioning/src/main/java/org/wildfly/build/pack/model/FeaturePackFactory.java
@@ -46,18 +46,19 @@ public class FeaturePackFactory {
     private static final String MODULES_ENTRY_NAME_PREFIX = Locations.MODULES + "/";
     private static final String CONTENT_ENTRY_NAME_PREFIX = Locations.CONTENT + "/";
 
-    public static FeaturePack createPack(final Artifact artifactCoords, final ArtifactFileResolver artifactFileResolver, ArtifactResolver versionOverrideResolver) {
-        return createPack(artifactCoords, artifactFileResolver, versionOverrideResolver, new HashSet<Artifact>());
+    public static FeaturePack createPack(final Artifact artifactCoords, final PropertyResolver propertyResolver, final ArtifactFileResolver artifactFileResolver, ArtifactResolver versionOverrideResolver) {
+        return createPack(artifactCoords, propertyResolver, artifactFileResolver, versionOverrideResolver, new HashSet<Artifact>());
     }
 
     /**
      *
      * @param artifactCoords the coordinates of the feature pack artifact
+     * @param propertyResolver the Maven properties resolver
      * @param artifactFileResolver the artifact -> artifact file resolver
      * @param processedFeaturePacks a set containing all parent feature packs, useful to detect cyclic dependencies
      * @return
      */
-    private static FeaturePack createPack(final Artifact artifactCoords, final ArtifactFileResolver artifactFileResolver, ArtifactResolver versionOverrideResolver, Set<Artifact> processedFeaturePacks) {
+    private static FeaturePack createPack(final Artifact artifactCoords, final PropertyResolver propertyResolver, final ArtifactFileResolver artifactFileResolver, ArtifactResolver versionOverrideResolver, Set<Artifact> processedFeaturePacks) {
         if (!processedFeaturePacks.add(artifactCoords)) {
             throw new IllegalStateException("Cyclic dependency, feature pack "+artifactCoords+" already processed! Feature packs: "+processedFeaturePacks);
         }
@@ -93,9 +94,9 @@ public class FeaturePackFactory {
             // create dependencies feature packs
             final List<FeaturePack> dependencies = new ArrayList<>();
             for (String dependency : description.getDependencies()) {
-                dependencies.add(createPack(artifactResolver.getArtifact(dependency), artifactFileResolver, versionOverrideResolver, new HashSet<>(processedFeaturePacks)));
+                dependencies.add(createPack(artifactResolver.getArtifact(dependency), propertyResolver, artifactFileResolver, versionOverrideResolver, new HashSet<>(processedFeaturePacks)));
             }
-            return new FeaturePack(artifactFile, artifactCoords, description, dependencies, artifactResolver, configurationFiles, modulesFiles, contentFiles);
+            return new FeaturePack(artifactFile, artifactCoords, description, dependencies, propertyResolver, artifactResolver, configurationFiles, modulesFiles, contentFiles);
         } catch (Throwable e) {
             throw new RuntimeException("Failed to create feature pack from " + artifactCoords, e);
         }

--- a/provisioning/src/main/java/org/wildfly/build/provisioning/ServerProvisioner.java
+++ b/provisioning/src/main/java/org/wildfly/build/provisioning/ServerProvisioner.java
@@ -173,7 +173,14 @@ public class ServerProvisioner {
         for (CopyArtifact copyArtifact : copyArtifacts) {
 
             //first resolve the artifact
-            Artifact artifact = artifactResolver.getArtifact(copyArtifact.getArtifact());
+            CopyArtifact.ArtifactName artifactName = copyArtifact.getArtifact();
+
+            Artifact artifact;
+            if (artifactName.hasVersion()) {
+                artifact = artifactName.getArtifact();
+            } else {
+                artifact = artifactResolver.getArtifact(artifactName.getArtifactCoords());
+            }
             if (artifact == null) {
                 throw new RuntimeException("Could not resolve artifact " + copyArtifact.getArtifact() + " to copy");
             }

--- a/provisioning/src/main/java/org/wildfly/build/util/ModuleParseResult.java
+++ b/provisioning/src/main/java/org/wildfly/build/util/ModuleParseResult.java
@@ -30,7 +30,7 @@ import org.wildfly.build.pack.model.ModuleIdentifier;
  */
 public class ModuleParseResult {
     final List<ModuleDependency> dependencies = new ArrayList<ModuleDependency>();
-    final List<String> resourceRoots = new ArrayList<>();
+    final List<ResourceRoot> resourceRoots = new ArrayList<>();
     final List<ArtifactName> artifacts = new ArrayList<>();
     final Document document;
     ModuleIdentifier identifier;
@@ -44,7 +44,7 @@ public class ModuleParseResult {
         return dependencies;
     }
 
-    public List<String> getResourceRoots() {
+    public List<ResourceRoot> getResourceRoots() {
         return resourceRoots;
     }
 
@@ -141,6 +141,30 @@ public class ModuleParseResult {
             } else {
                 return new Artifact(parts[0], parts[1], parts[3], "jar", parts[2]);
             }
+        }
+    }
+
+    public static class ResourceRoot {
+
+        private final String path;
+        private final Attribute attribute;
+
+        public ResourceRoot(String path, final Attribute attribute) {
+            this.path = path;
+            this.attribute = attribute;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public Attribute getAttribute() {
+            return attribute;
+        }
+
+        @Override
+        public String toString() {
+            return path;
         }
     }
 }


### PR DESCRIPTION
Hi @stuartwdouglas ,

Following our discussions, I made progress on the BV/HV upgrade.

This PR is for discussion, I'll open proper JIRA issues and will amend the commit messages once we come to an agreement on which commit should go in.

Commit descriptions:

## Support specifying the version in copy-artifact

I think this one is self explanatory, it adds the support of your recent work allowing to hardcode the version of an artifact to the `<copy-artifact>` element of the feature pack descriptor.

This way, I can:
- use a properly declared artifact for Bean Validation 2.0
- use a `<copy-artifact>` element with Bean Validation 1.1 declaring the exact version (1.1.0.Final) to copy the jar in the module directory and then use it with a `<resource-root>` element.

-> this way, I can use 2 versions of the same groupdId/artifactId

## Support replacing properties in `<artifact name="" />` and `<resource-root path="" />`

This patch is a bit verbose as I had to inject the `PropertyResolver` in quite a lot of places but it's indeed quite simple: we replace the properties in `<artifact name="" />` and `<resource-root path="" />` and, in addition to rewriting the `<artifact>` elements to `<resource-root>` elements when provisioning, we also update the `<resource-root>` elements with the updated values.

So the provisioning part is well covered with this patch.

There is one issue I see with this patch though: the module.xml files are copied as is when building the feature-pack so the feature-pack has the module.xml with the property placeholder. This means that when using the feature pack, you will need the property to be defined. I don't think that's acceptable.

We could maybe filter the module.xml files when building the feature pack, either by using a mechanism similar to what is done by the maven-resources-plugin or with our own mechanism.

I wasn't very sure of what we would want to do with this. Maybe it's a dead end.

The direct consequence of not having this patch is that I will need to hardcode the version in the module.xml whereas I can use a proper property in the feature pack descriptor.


