### PR TITLE
WFBUILD-39 - Wildfly-build-tools ignores dependency management

### DIFF
--- a/feature-pack-build-maven-plugin/src/test/java/org/wildfly/build/plugin/MavenProjectArtifactResolverTestCase.java
+++ b/feature-pack-build-maven-plugin/src/test/java/org/wildfly/build/plugin/MavenProjectArtifactResolverTestCase.java
@@ -1,0 +1,46 @@
+package org.wildfly.build.plugin;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileReader;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.MavenProject;
+import org.junit.Test;
+import org.wildfly.build.pack.model.Artifact;
+import static org.junit.Assert.assertEquals;
+
+public class MavenProjectArtifactResolverTestCase {
+    private final String pomWithDependencies = "pom-with-no-dependencies.xml";
+    private final String pomWithDependencyManagement = "pom-with-dependencymanagement.xml";
+
+    @Test
+    public void pomWithDependencyManagementTest() throws Exception {
+        MavenProjectArtifactResolver mavenProjectArtifactResolver = loadConfigFile(pomWithDependencyManagement);
+        assertEquals(mavenProjectArtifactResolver.getArtifact(getArtifact()).getVersion(), "1.7.22.redhat-2");
+    }
+
+    @Test
+    public void pomWithnoDependenciesTest() throws Exception {
+        MavenProjectArtifactResolver mavenProjectArtifactResolver = loadConfigFile(pomWithDependencies);
+        assertEquals(mavenProjectArtifactResolver.getArtifact(getArtifact()), null);
+    }
+
+    private MavenProjectArtifactResolver loadConfigFile(String filename) throws Exception {
+        MavenXpp3Reader pomReader = new MavenXpp3Reader();
+        Model model = null;
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        model = pomReader.read(new FileReader(new File(classLoader.getResource(filename).getFile())));
+        MavenProject project = new MavenProject(model);
+        MavenProjectArtifactResolver mavenProjectArtifactResolver = new MavenProjectArtifactResolver(project);
+        return mavenProjectArtifactResolver;
+    }
+
+    private Artifact getArtifact() {
+        return new Artifact("org.slf4j", "slf4j-api", null, null, null);
+    }
+
+}

--- a/feature-pack-build-maven-plugin/src/test/resources/pom-with-dependencymanagement.xml
+++ b/feature-pack-build-maven-plugin/src/test/resources/pom-with-dependencymanagement.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jboss.set</groupId>
+    <artifactId>wildfly-build-tools-test</artifactId>
+    <version>0.0.0-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.22.redhat-2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    
+</project>

--- a/feature-pack-build-maven-plugin/src/test/resources/pom-with-no-dependencies.xml
+++ b/feature-pack-build-maven-plugin/src/test/resources/pom-with-no-dependencies.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jboss.set</groupId>
+    <artifactId>wildfly-build-tools-test</artifactId>
+    <version>0.0.0-SNAPSHOT</version>
+    
+</project>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFBUILD-39

allow-maven-version-overrides was introduced in this pr [1], there there is a description:

Maven plugins may optionally complement/override <artifact-refs/>, through the maven project dependencies. Each dependency artifact is mapped to the artifact name <groupId>:<artifactId>[::<classifier>]. Note that this functionality is only activated if property named use-maven-project-artifact-resolver is set. By default, the property is only set for the feature pack build plugin.

The problem is that only direct dependencies are used and not the ones from the dependencymanagement element, added processing of this element to fix the problem. 

[1] https://github.com/wildfly/wildfly-build-tools/pull/15